### PR TITLE
Rename Algebra#substract to Algebra#subtract

### DIFF
--- a/lib/auom/algebra.rb
+++ b/lib/auom/algebra.rb
@@ -31,7 +31,7 @@ module AUOM
 
     alias_method :+, :add
 
-    # Return substraction result
+    # Return subtraction result
     #
     # @param [Object] operand
     #
@@ -50,11 +50,11 @@ module AUOM
     #
     # @api public
     #
-    def substract(operand)
+    def subtract(operand)
       add(operand * -1)
     end
 
-    alias_method :-, :substract
+    alias_method :-, :subtract
 
     # Return multiplication result
     #

--- a/spec/unit/auom/algebra/substract_spec.rb
+++ b/spec/unit/auom/algebra/substract_spec.rb
@@ -2,8 +2,8 @@
 
 require 'spec_helper'
 
-describe AUOM::Algebra, '#substract' do
-  subject { object.substract(operand) }
+describe AUOM::Algebra, '#subtract' do
+  subject { object.subtract(operand) }
 
   let(:object) { AUOM::Unit.new(*arguments) }
 


### PR DESCRIPTION
Note: This PR breaks the API.

Maybe an alias to `substract` should be added?
