### PR TITLE
Upgrade ruby requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 script: 'bundle exec rake ci'
 rvm:
-  - 2.1
+  - 2.4
   - rbx
 matrix:
   include:

--- a/auom.gemspec
+++ b/auom.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths    = %w(lib)
   s.extra_rdoc_files = %w(TODO LICENSE)
 
-  s.required_ruby_version = '>= 2.1'
+  s.required_ruby_version = '>= 2.4'
 
   s.add_dependency('equalizer', '~> 0.0.9')
 end

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 ---
 machine:
   ruby:
-    version: '2.2'
+    version: '2.4'
 test:
   override:
     - bundle exec rake ci


### PR DESCRIPTION
I don't know whether you'd want to require 2.4, but that's when the deprecation warnings for `Fixnum` start, and since I'm submitting a separate PR for addressing that, I thought I'd aim for 2.4.

I don't use rvm, but I guessed that bumping the value for `rvm` in travis was a good idea. 